### PR TITLE
Add shared Conductor settings

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,7 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "bun install --frozen-lockfile"
+run = "bun run dev -- --host 0.0.0.0 --port $CONDUCTOR_PORT"
+archive = "true"
+run_mode = "concurrent"


### PR DESCRIPTION
Adds a repo-level Conductor settings file for shared workspace setup and run behavior.
The setup script uses Bun with the frozen lockfile, the run script starts Astro on `$CONDUCTOR_PORT`, and concurrent run mode is enabled because the app has no shared local service.
Validation: `npx -y @taplo/cli lint --schema https://conductor.build/schemas/settings.repo.schema.json .conductor/settings.toml`.
